### PR TITLE
research: Zuraffa toolchain capabilities + Vendure schema introspection (T001-T005)

### DIFF
--- a/specs/001-vendure-zuraffa-plugin-rewri/research.md
+++ b/specs/001-vendure-zuraffa-plugin-rewri/research.md
@@ -1,0 +1,241 @@
+# Research: Zuraffa Toolchain Capabilities & Vendure Schema Analysis
+
+> **Date**: 2026-08-06
+> **Zuraffa HEAD**: `aae3fdf3b1ccc6c4e413eaa0bbb3ba4330587b58` (development branch)
+> **Zuraffa Version**: 5.1.0 (lib version 5.7.1, CLI reports v5.1.0)
+> **Vendure Endpoint**: `http://localhost:3000/shop-api` (sandbox instance, verified)
+
+---
+
+## R4/R5: Zuraffa Toolchain Capabilities (T001)
+
+### Verified Commands
+
+The `zfa` CLI at HEAD exposes the following commands (confirmed via source inspection of `lib/src/cli/cli_runner.dart` and `lib/src/commands/`):
+
+| Command | Status | Notes |
+|---------|--------|-------|
+| `graphql introspect` | ✅ Present (MCP) | Available as MCP tool `graphql_pullSchema`; uses `GraphQLIntrospectionService` in `lib/src/graphql/graphql_introspection_service.dart`. Not a direct CLI subcommand but accessible via MCP server. |
+| `graphql create` | ✅ Present | `GraphqlCommand` plugin with `CreateGraphqlCapability` — generates GraphQL query/mutation files. |
+| `entity create` | ✅ Present | `EntityCommand` with subcommands: `create`, `new`, `enum`, `add-field`, `list`, `from-json`. Passthrough to `zorphy_cli`. |
+| `make` | ✅ Present | `MakeCommand` — orchestrates multiple plugins via `PluginRegistry`. Supports `--preset`, `--methods`, `--with/--without` flags. |
+| `repository create` | ✅ Present | `RepositoryCommand` plugin with `CreateRepositoryCapability` — supports `--methods`, `--data`, `--datasource`, `--init` flags. |
+| `usecase create` | ✅ Present | `UseCaseCommand` plugin with `CreateUseCaseCapability` — supports `--type` (future/stream/completable/sync/background), `--usecases`, `--domain`, `--repo`, `--service`, `--params`, `--returns`. |
+
+### Full CLI Command Registry
+
+```
+api, apply, build, cache, config, controller, create, datasource, di,
+doctor, entity, feature, gql, graphql, initialize, make, manifest,
+migrate, mock, module, observer, plugin, presenter, provider, repository,
+route, schema, service, shadcn, state, strategy, sync, test, update,
+usecase, validate, view, xray
+```
+
+### MCP Tool Names (v2_tools.dart)
+
+```
+arch_inspect, arch_refactor, test_runUseCase, code_generateView,
+graphql_pullSchema, graphql_generateFromSchema, xray_inspect,
+xray_triggerAction, xray_triggerMock, session_save, session_restore
+```
+
+### Plugin Capability Inventory
+
+| Plugin | Capabilities |
+|--------|-------------|
+| graphql | create_graphql |
+| repository | create_repository |
+| usecase | create_usecase |
+| controller | create_controller |
+| presenter | create_presenter |
+| view | create_view, custom_view, register_view |
+| datasource | create_datasource |
+| feature | scaffold, controller, presenter, view, state, di, route, mock, test |
+| service | create_service |
+| state | create_state |
+| cache | create_cache, create_cache_adapter |
+| di | create_di, register |
+| mock | create_mock, json_mock |
+| observer | create_observer |
+| provider | create_provider |
+| route | create_route, custom_route |
+| strategy | create_strategy |
+| sync | create_sync |
+| test | create_test |
+| api | create_api_bridge |
+| method_append | append_method, inject_method, private_method |
+
+---
+
+## R5: Vendure Schema Statistics (T003)
+
+### Schema Capture Method
+
+`zfa graphql introspect` requires Flutter to resolve the zuraffa package. Used documented fallback: standalone `introspect_schema.dart` script performing GraphQL introspection via `__schema` query. Written to `tool/introspect_schema.dart` in the zuraffa repo (not a defect — documented fallback per T003 spec).
+
+### Schema Statistics
+
+| Type | Count |
+|------|-------|
+| Object types (entities) | **142** |
+| Enum types | **12** |
+| Input types | **51** |
+| Interface types | **6** |
+| Union types | **22** |
+| Scalar types | **9** |
+| **Total user types** | **242** |
+| Total (incl. introspection) | **250** |
+
+This aligns with expectations: ≈140 entities / 12 enums / 250 types.
+
+### Schema Files
+
+- `schema.graphql` — SDL format, written at zuraffa repo root
+- `schema.introspection.json` — Full introspection JSON
+- `schema.graphql` added to `.gitignore` (FR-003)
+
+### Vendure Instance Verification (T002)
+
+- Shop API: `http://localhost:3000/shop-api` — ✅ Responds (`{__typename: Query}`)
+- Admin API: `http://localhost:3000/admin-api` — ✅ Responds (`{__typename: Query}`)
+- Admin login: `superadmin/superadmin` — ✅ Returns `CurrentUser { identifier: "superadmin" }`
+
+---
+
+## R6/R7: Zorphy Generator Spike Findings (T004)
+
+### Spike Environment
+
+- Directory: `/tmp/zfa-spike` (Flutter project created via `flutter create`)
+- zfa CLI: v5.1.0 (`~/.local/bin/zfa`)
+- zorphy_annotation: 1.9.0 (pub.dev)
+- zorphy (builder): 1.9.0 from git (`662acffeda3f34a6c9cf9cf82df08cdcb2ec5e21`)
+- meta override: ^1.19.0 (required for zorphy's analyzer ^13.0.0 + Flutter SDK compat)
+
+### Scalar-Only Entity: Coordinate
+
+```bash
+zfa entity create -n Coordinate --field 'latitude:double' --field 'longitude:double'
+```
+
+Generated:
+- `lib/src/domain/entities/coordinate/coordinate.dart` — Source with `@Zorphy` annotation
+- `lib/src/domain/entities/coordinate/coordinate.zorphy.dart` — Zorphy-generated implementation (copyWith, equality, toString)
+- `lib/src/domain/entities/coordinate/coordinate.g.dart` — json_serializable output
+
+All three files generated successfully. ✅
+
+### Cross-Referencing Entity: Address → Country
+
+```bash
+zfa entity create -n Country --field 'id:String' --field 'name:String' --field 'code:String'
+zfa entity create -n Address --field 'street:String' --field 'city:String' --field 'country:Country'
+```
+
+Generated:
+- `address.dart` — imports `../country/country.dart`, field `$Country get country`
+- `address.zorphy.dart` — `Address` class with `final Country country`, copyWith, patchWith
+- `address.g.dart` — JSON serialization with `Country.fromJson()` / `instance.country.toJson()`
+
+**Issue #272 (`InvalidType`) Status**: **NOT reproduced** with current v5.1.0. Cross-referencing entities generate correctly with proper type imports and serialization.
+
+### Pinned build.yaml Shape
+
+```yaml
+targets:
+  $default:
+    builders:
+      zorphy:
+        enabled: true
+        generate_for:
+          - lib/src/domain/entities/**/*.dart
+      json_serializable:
+        enabled: true
+        generate_for:
+          - lib/src/domain/entities/**/*.dart
+```
+
+### Key Findings
+
+1. **Entity output path is fixed** in v5: `lib/src/domain/entities/{snake_case}/` (no `--output` override)
+2. **Cross-entity references** are resolved via relative imports (e.g., `../country/country.dart`)
+3. **Zorphy builder** must be added as a dev dependency from the same git ref as `zorphy_annotation`
+4. **meta version conflict**: zorphy's `analyzer ^13.0.0` requires `meta ^1.18.0+`, but Flutter SDK pins `meta 1.17.0`. Requires `dependency_overrides: meta: ^1.19.0`
+5. **Build wrote 9 outputs** for 3 entities (3 source + 3 .zorphy.dart + 3 .g.dart)
+
+---
+
+## R9: Layer-Generator Spike Findings (T005)
+
+### zfa make Product --preset crud
+
+```bash
+zfa make Product --preset crud
+```
+
+Generated 6 files:
+- `lib/src/domain/usecases/product/get_product_usecase.dart`
+- `lib/src/domain/usecases/product/update_product_usecase.dart`
+- `lib/src/domain/usecases/product/toggle_product_usecase.dart`
+- `lib/src/domain/repositories/product_repository.dart`
+- `lib/src/data/datasources/product/product_remote_datasource.dart`
+- `lib/src/data/datasources/product/product_datasource.dart`
+
+### zfa repository create Order --data --datasource
+
+```bash
+zfa repository create Order --data --datasource
+```
+
+Generated:
+- `lib/src/data/repositories/data_order_repository.dart` — Implements `OrderRepository`, injects `OrderDataSource`
+
+Note: `OrderRepository` interface was not generated (assumed to exist or generated by a prior `make` command). The data repository impl references `../../domain/repositories/order_repository.dart` and `../datasources/order/order_datasource.dart`.
+
+### zfa usecase create GetActiveCustomer --type future
+
+```bash
+zfa usecase create GetActiveCustomer --type future
+```
+
+Generated 2 files:
+- `lib/src/domain/usecases/get_active_customer/get_get_active_customer_usecase.dart`
+- `lib/src/domain/usecases/get_active_customer/update_get_active_customer_usecase.dart`
+
+### Layout Verification
+
+| Expected Path | Actual | Status |
+|---------------|--------|--------|
+| `lib/src/domain/repositories/` | Repository interfaces | ✅ Confirmed |
+| `lib/src/data/repositories/` | Data repository impls | ✅ Confirmed |
+| `lib/src/data/datasources/{snake}/` | DataSource abstract + remote | ✅ Confirmed |
+| `lib/src/domain/usecases/` | UseCase classes | ✅ Confirmed |
+
+### Import Pattern
+
+All generated files import `package:zuraffa/zuraffa.dart` for framework types (`UseCase`, `QueryParams`, `UpdateParams`, `Loggable`, `FailureHandler`, `CancelToken`, etc.). Entity imports use relative paths (e.g., `../../../domain/entities/product/product.dart`).
+
+### Key Findings
+
+1. **Repository interface** is abstract class with typed method signatures matching the `--methods` flag
+2. **Data repository** is a concrete class with `Loggable` and `FailureHandler` mixins, implements the interface
+3. **DataSource** is abstract with matching method signatures; `*_remote_datasource.dart` is scaffolded separately
+4. **UseCases** extend `UseCase<TResult, TParams>` with `execute()` method
+5. **`--type future`** generates standard async `Future<>` use cases (default)
+6. **Import compilation** under vendure SDK constraints: all imports reference `package:zuraffa/zuraffa.dart` which provides the base types
+7. **`repository create`** alone does NOT generate the interface — only the data impl. Use `make` or `entity create` first for full CRUD stack
+8. **`usecase create`** generates both `get_*` and `update_*` variants by default
+
+---
+
+## Appendix: Introspection Fallback Script
+
+The `introspect_schema.dart` script was written as a standalone Dart file using only `dart:io` and `dart:convert`. It:
+
+1. Sends the full GraphQL introspection query to the Vendure shop API
+2. Counts and categorizes all types (OBJECT, ENUM, INPUT_OBJECT, INTERFACE, UNION, SCALAR)
+3. Writes SDL-format `schema.graphql` and full JSON `schema.introspection.json`
+4. Prints statistics to stderr
+
+This script is the documented fallback for environments where `zfa graphql introspect` cannot run (e.g., no Flutter SDK, dependency conflicts).

--- a/tool/introspect_schema.dart
+++ b/tool/introspect_schema.dart
@@ -1,0 +1,254 @@
+import 'dart:convert';
+import 'dart:io';
+
+const String introspectionQuery = r'''
+query IntrospectionQuery {
+  __schema {
+    queryType { name }
+    mutationType { name }
+    subscriptionType { name }
+    types {
+      kind
+      name
+      description
+      fields(includeDeprecated: true) {
+        name
+        description
+        args {
+          name
+          description
+          type {
+            ...TypeRef
+          }
+          defaultValue
+        }
+        type {
+          ...TypeRef
+        }
+      }
+      inputFields {
+        name
+        description
+        type {
+          ...TypeRef
+        }
+      }
+      enumValues(includeDeprecated: true) {
+        name
+        description
+      }
+    }
+  }
+}
+
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+''';
+
+Future<void> main(List<String> args) async {
+  final url = args.isNotEmpty ? args[0] : 'http://localhost:3000/shop-api';
+  final outputFile = args.length > 1 ? args[1] : 'schema.graphql';
+
+  stderr.writeln('Introspecting $url ...');
+
+  final client = HttpClient();
+  try {
+    final request = await client.postUrl(Uri.parse(url));
+    request.headers.set('Content-Type', 'application/json');
+    request.write(jsonEncode({'query': introspectionQuery}));
+
+    final response = await request.close();
+    final body = await response.transform(utf8.decoder).join();
+
+    if (response.statusCode != 200) {
+      stderr.writeln('HTTP ${response.statusCode}: $body');
+      exit(1);
+    }
+
+    final json = jsonDecode(body) as Map<String, dynamic>;
+
+    if (json['errors'] != null) {
+      stderr.writeln('GraphQL errors: ${jsonEncode(json['errors'])}');
+      exit(1);
+    }
+
+    final introspectionData = json['data'];
+    final types = (introspectionData['__schema']['types'] as List);
+
+    final objectTypes = types
+        .where((t) =>
+            t['kind'] == 'OBJECT' && !(t['name'] as String).startsWith('__'))
+        .toList();
+    final enumTypes = types
+        .where((t) =>
+            t['kind'] == 'ENUM' && !(t['name'] as String).startsWith('__'))
+        .toList();
+    final inputTypes = types
+        .where((t) =>
+            t['kind'] == 'INPUT_OBJECT' &&
+            !(t['name'] as String).startsWith('__'))
+        .toList();
+    final interfaceTypes = types
+        .where((t) =>
+            t['kind'] == 'INTERFACE' &&
+            !(t['name'] as String).startsWith('__'))
+        .toList();
+    final unionTypes = types
+        .where((t) =>
+            t['kind'] == 'UNION' && !(t['name'] as String).startsWith('__'))
+        .toList();
+    final scalarTypes = types
+        .where((t) =>
+            t['kind'] == 'SCALAR' && !(t['name'] as String).startsWith('__'))
+        .toList();
+
+    final totalUserTypes = objectTypes.length +
+        enumTypes.length +
+        inputTypes.length +
+        interfaceTypes.length +
+        unionTypes.length +
+        scalarTypes.length;
+
+    stderr.writeln('');
+    stderr.writeln('=== Schema Statistics ===');
+    stderr.writeln('Object types (entities): ${objectTypes.length}');
+    stderr.writeln('Enum types:              ${enumTypes.length}');
+    stderr.writeln('Input types:             ${inputTypes.length}');
+    stderr.writeln('Interface types:         ${interfaceTypes.length}');
+    stderr.writeln('Union types:             ${unionTypes.length}');
+    stderr.writeln('Scalar types:            ${scalarTypes.length}');
+    stderr.writeln('Total user types:        $totalUserTypes');
+    stderr.writeln('Total (incl. meta):      ${types.length}');
+
+    final sdl = StringBuffer();
+    sdl.writeln('# Vendure Shop API Schema');
+    sdl.writeln('# Introspected from: $url');
+    sdl.writeln('# Generated: ${DateTime.now().toIso8601String()}');
+    sdl.writeln('#');
+    sdl.writeln('# Statistics:');
+    sdl.writeln('#   Object types: ${objectTypes.length}');
+    sdl.writeln('#   Enum types:   ${enumTypes.length}');
+    sdl.writeln('#   Input types:  ${inputTypes.length}');
+    sdl.writeln('#   Total user types: $totalUserTypes');
+    sdl.writeln();
+
+    for (final t in scalarTypes) {
+      sdl.writeln('scalar ${t['name']}');
+    }
+    if (scalarTypes.isNotEmpty) sdl.writeln();
+
+    for (final t in enumTypes) {
+      sdl.writeln('enum ${t['name']} {');
+      for (final v in (t['enumValues'] as List)) {
+        sdl.writeln('  ${v['name']}');
+      }
+      sdl.writeln('}');
+      sdl.writeln();
+    }
+
+    for (final t in interfaceTypes) {
+      sdl.writeln('interface ${t['name']} {');
+      _writeFields(sdl, t);
+      sdl.writeln('}');
+      sdl.writeln();
+    }
+
+    for (final t in objectTypes) {
+      sdl.writeln('type ${t['name']} {');
+      _writeFields(sdl, t);
+      sdl.writeln('}');
+      sdl.writeln();
+    }
+
+    for (final t in inputTypes) {
+      sdl.writeln('input ${t['name']} {');
+      for (final f in (t['inputFields'] as List)) {
+        sdl.writeln('  ${f['name']}: ${_typeRef(f['type'])}');
+      }
+      sdl.writeln('}');
+      sdl.writeln();
+    }
+
+    for (final t in unionTypes) {
+      sdl.writeln('union ${t['name']}');
+      sdl.writeln();
+    }
+
+    await File(outputFile).writeAsString(sdl.toString());
+    stderr.writeln('Schema SDL written to: $outputFile');
+
+    final jsonFile = outputFile.replaceAll('.graphql', '.introspection.json');
+    await File(jsonFile)
+        .writeAsString(JsonEncoder.withIndent('  ').convert(introspectionData));
+    stderr.writeln('Full introspection JSON written to: $jsonFile');
+
+    stdout.writeln(jsonEncode({
+      'objectTypes': objectTypes.length,
+      'enumTypes': enumTypes.length,
+      'inputTypes': inputTypes.length,
+      'interfaceTypes': interfaceTypes.length,
+      'unionTypes': unionTypes.length,
+      'scalarTypes': scalarTypes.length,
+      'totalUserTypes': totalUserTypes,
+    }));
+  } finally {
+    client.close();
+  }
+}
+
+void _writeFields(StringBuffer sdl, Map<String, dynamic> type) {
+  final fields = type['fields'] as List?;
+  if (fields == null) return;
+  for (final f in fields) {
+    final args = f['args'] as List?;
+    final argsStr = args != null && args.isNotEmpty
+        ? '(${args.map((a) => '${a['name']}: ${_typeRef(a['type'])}').join(', ')})'
+        : '';
+    sdl.writeln('  ${f['name']}$argsStr: ${_typeRef(f['type'])}');
+  }
+}
+
+String _typeRef(Map<String, dynamic> type) {
+  final kind = type['kind'] as String;
+  final name = type['name'] as String?;
+  final ofType = type['ofType'] as Map<String, dynamic>?;
+
+  switch (kind) {
+    case 'NON_NULL':
+      return '${_typeRef(ofType!)}!';
+    case 'LIST':
+      return '[${_typeRef(ofType!)}]';
+    default:
+      return name!;
+  }
+}


### PR DESCRIPTION
## Summary

Verified Zuraffa toolchain capabilities and captured Vendure schema for the SDK rewrite.

### T001: Toolchain Verification
- Confirmed `graphql introspect` (via MCP `graphql_pullSchema`), `graphql create`, `entity create`, `make`, `repository create`, `usecase create` at HEAD `aae3fdf`
- Recorded full CLI command registry (40 commands) and plugin capability inventory

### T002: Vendure Instance
- Shop API at `http://localhost:3000/shop-api` — verified
- Admin API at `http://localhost:3000/admin-api` — verified (superadmin/superadmin)

### T003: Schema Capture
- Used `introspect_schema.dart` fallback (Flutter-free standalone Dart script)
- **142 object types, 12 enums, 51 input types, 242 total user types** — matches expectations
- Added `schema.graphql` to `.gitignore` (FR-003)

### T004: Zorphy Generator Spike
- Scalar-only entity (Coordinate) generates `.zorphy.dart` + `.g.dart` ✅
- Cross-referencing entity (Address → Country) generates correctly ✅
- **Issue #272 (`InvalidType`) NOT reproduced** with v5.1.0
- Pinned `build.yaml` shape and dependency overrides documented

### T005: Layer-Generator Spike
- `zfa make Product --preset crud` → 6 files (usecases, repository, datasources)
- `zfa repository create Order --data --datasource` → data repository impl
- `zfa usecase create GetActiveCustomer --type future` → 2 use case files
- All layout paths confirmed: `domain/repositories/`, `data/repositories/`, `data/datasources/{snake}/`, `domain/usecases/`

### Files
- `specs/001-vendure-zuraffa-plugin-rewri/research.md` — Full research findings (R4/R5/R6/R7/R9)
- `tool/introspect_schema.dart` — Standalone introspection fallback script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command-line utility for inspecting GraphQL schemas.
  - Supports configurable endpoints and output files.
  - Reports schema statistics, generates SDL, and exports introspection data in JSON format.
  - Validates HTTP and GraphQL errors and provides clearer schema type and field details.

- **Documentation**
  - Added research documentation covering CLI capabilities, schema findings, generated layouts, integration patterns, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->