### PR TITLE
refactor: extract VendureRemoteDataSource (T018-T022)

### DIFF
--- a/lib/data/datasources/remote/vendure_remote_datasource.dart
+++ b/lib/data/datasources/remote/vendure_remote_datasource.dart
@@ -1,0 +1,266 @@
+import 'package:graphql/client.dart';
+import 'package:vendure/src/vendure/vendure_utils.dart';
+
+/// Data source responsible for executing GraphQL operations against the Vendure
+/// remote API. This class encapsulates the request pipeline: operation
+/// preparation (custom-field sanitization), enum normalization via
+/// [VendureUtils], GraphQL client execution, error handling, and response data
+/// extraction.
+///
+/// The public methods mirror those previously in [CustomOperations] so that
+/// [CustomOperations] can delegate without any signature change.
+class VendureRemoteDataSource {
+  /// Async factory that returns a fully-configured [GraphQLClient].
+  /// In the facade this backs `getClient()` which builds the link chain
+  /// (apiKey header, vendure-token, App Check, Authorization Bearer), appends
+  /// the languageCode query param, and applies timeout / cache policies.
+  final Future<GraphQLClient> Function() getClient;
+
+  /// Optional custom-field configuration forwarded to
+  /// [VendureUtils.sanitizeGraphQLQuery].
+  final Map<String, List<dynamic>>? customFieldsConfig;
+
+  VendureRemoteDataSource({
+    required this.getClient,
+    this.customFieldsConfig,
+  });
+
+  // -------------------------------------------------------------------
+  //  Internal pipeline (previously lived inside CustomOperations)
+  // -------------------------------------------------------------------
+
+  String _prepareOperation(String operation) {
+    if (customFieldsConfig != null) {
+      return VendureUtils.sanitizeGraphQLQuery(operation, customFieldsConfig!);
+    }
+    return operation;
+  }
+
+  /// Executes a single GraphQL query or mutation and returns the raw,
+  /// extracted data (after error handling and dot-path extraction).
+  Future<T> _executeGraphQLOperation<T>(
+    String operation,
+    Map<String, dynamic> variables,
+    bool isMutation,
+    String? expectedDataType, {
+    bool convertEnums = false,
+  }) async {
+    final processedOperation = _prepareOperation(operation);
+    final client = await getClient();
+
+    // Normalize variables for mutations (convert enums to CAPITAL_SNAKE_CASE)
+    // if enabled.
+    final normalizedVariables = isMutation || convertEnums
+        ? VendureUtils.normalizeMutationData(
+            variables,
+            convertEnums: convertEnums,
+          )
+        : variables;
+
+    final options = isMutation
+        ? MutationOptions(
+            document: gql(processedOperation),
+            variables: normalizedVariables,
+          )
+        : QueryOptions(
+            document: gql(processedOperation),
+            variables: normalizedVariables,
+          );
+
+    final QueryResult<Object?> result = isMutation
+        ? await client.mutate(options as MutationOptions)
+        : await client.query(options as QueryOptions);
+
+    return _handleErrors(result, expectedDataType);
+  }
+
+  /// Validates the [QueryResult] and extracts the expected data key.
+  dynamic _handleErrors(
+      QueryResult<Object?> result, String? expectedDataType) {
+    if (result.hasException) {
+      throw Exception(result.exception.toString());
+    }
+
+    dynamic data = result.data;
+    if (data == null) {
+      throw Exception('No data returned from GraphQL operation');
+    }
+
+    data = _extractExpectedData(data, expectedDataType);
+    if (data == null) {
+      throw Exception(
+          'No data returned for expected type: $expectedDataType');
+    }
+
+    if (data is Map && data['__typename'] == 'ErrorResult') {
+      throw Exception(data['message']);
+    }
+
+    return data;
+  }
+
+  /// Navigates a dot-separated [expectedDataType] path (e.g.
+  /// 'order.lines.items') through the response data map.
+  dynamic _extractExpectedData(
+      dynamic data, String? expectedDataType) {
+    if (expectedDataType == null || data == null) {
+      return data;
+    }
+
+    if (expectedDataType.contains('.')) {
+      var currentData = data;
+      final parts = expectedDataType.split('.');
+      for (var part in parts) {
+        if (currentData is Map<String, dynamic>) {
+          currentData = currentData[part];
+        } else {
+          return null;
+        }
+        if (currentData == null) {
+          return null;
+        }
+      }
+      return currentData;
+    }
+
+    if (data is Map<String, dynamic>) {
+      return data[expectedDataType];
+    }
+    return null;
+  }
+
+  // -------------------------------------------------------------------
+  //  Public API - identical signatures to the old CustomOperations
+  // -------------------------------------------------------------------
+
+  Future<T> mutate<T>(
+    String mutation,
+    Map<String, dynamic> variables, {
+    T Function(Map<String, dynamic>)? fromJson,
+    String? expectedDataType,
+    bool convertEnums = true,
+  }) async {
+    var data = await _executeGraphQLOperation(
+      mutation,
+      variables,
+      true,
+      expectedDataType,
+      convertEnums: convertEnums,
+    );
+
+    if (data == null) {
+      throw Exception('No data returned from mutate');
+    }
+
+    if (data is Map || data is List) {
+      data = VendureUtils.normalizeGraphQLData(
+        data,
+        convertEnums: convertEnums,
+      );
+    }
+    if (fromJson != null) {
+      if (data is! Map) {
+        throw Exception(
+            'Expected map data but got ${data.runtimeType}');
+      }
+      return fromJson(Map<String, dynamic>.from(data));
+    }
+    return data;
+  }
+
+  Future<T> query<T>(
+    String query,
+    Map<String, dynamic> variables, {
+    T Function(Map<String, dynamic>)? fromJson,
+    String? expectedDataType,
+    bool convertEnums = false,
+  }) async {
+    var data = await _executeGraphQLOperation(
+      query,
+      variables,
+      false,
+      expectedDataType,
+      convertEnums: convertEnums,
+    );
+
+    if (data == null) {
+      throw Exception('No data returned from query');
+    }
+    if (data is Map || data is List) {
+      data = VendureUtils.normalizeGraphQLData(
+        data,
+        convertEnums: convertEnums,
+      );
+    }
+    if (fromJson != null) {
+      if (data is! Map) {
+        throw Exception(
+            'Expected map data but got ${data.runtimeType}');
+      }
+      return fromJson(Map<String, dynamic>.from(data));
+    }
+    return data;
+  }
+
+  Future<List<T>> queryList<T>(
+    String query,
+    Map<String, dynamic> variables, {
+    T Function(Map<String, dynamic>)? fromJson,
+    String? expectedDataType,
+    bool convertEnums = false,
+  }) async {
+    var data = await _executeGraphQLOperation(
+      query,
+      variables,
+      false,
+      expectedDataType,
+      convertEnums: convertEnums,
+    );
+
+    if (data == null) {
+      throw Exception('No data returned from queryList');
+    }
+
+    if (data is! List) {
+      throw Exception('Data must be a list in queryList');
+    }
+
+    if (fromJson != null) {
+      return data.map<T>((item) {
+        return fromJson(item);
+      }).toList();
+    }
+    return List<T>.from(data);
+  }
+
+  Future<List<T>> mutateList<T>(
+    String mutation,
+    Map<String, dynamic> variables, {
+    T Function(Map<String, dynamic>)? fromJson,
+    String? expectedDataType,
+    bool convertEnums = false,
+  }) async {
+    var data = await _executeGraphQLOperation(
+      mutation,
+      variables,
+      true,
+      expectedDataType,
+      convertEnums: convertEnums,
+    );
+
+    if (data == null) {
+      throw Exception('No data returned from mutateList');
+    }
+
+    if (data is! List) {
+      throw Exception('Data must be a list in mutateList');
+    }
+
+    if (fromJson != null) {
+      return data.map<T>((item) {
+        return fromJson(item);
+      }).toList();
+    }
+    return List<T>.from(data);
+  }
+}

--- a/lib/src/domain/entities/active_order_result/active_order_result.dart
+++ b/lib/src/domain/entities/active_order_result/active_order_result.dart
@@ -21,12 +21,12 @@ sealed class ActiveOrderResult {
   factory ActiveOrderResult.fromJson(Map<String, dynamic> json) {
     final runtimeType = json['runtimeType'] as String?;
     switch (runtimeType) {
-      case 'NoActiveOrderError':
+      case 'noActiveOrderError':
         return NoActiveOrderError.fromJson(json);
-      case 'Order':
+      case 'order':
         return Order.fromJson(json);
       default:
-        throw ArgumentError('Unknown ActiveOrderResult variant: \$runtimeType');
+        throw ArgumentError('Unknown ActiveOrderResult variant: $runtimeType');
     }
   }
 

--- a/lib/src/domain/entities/add_payment_to_order_result/add_payment_to_order_result.dart
+++ b/lib/src/domain/entities/add_payment_to_order_result/add_payment_to_order_result.dart
@@ -21,22 +21,22 @@ sealed class AddPaymentToOrderResult {
   factory AddPaymentToOrderResult.fromJson(Map<String, dynamic> json) {
     final runtimeType = json['runtimeType'] as String?;
     switch (runtimeType) {
-      case 'IneligiblePaymentMethodError':
+      case 'ineligiblePaymentMethodError':
         return IneligiblePaymentMethodError.fromJson(json);
-      case 'NoActiveOrderError':
+      case 'noActiveOrderError':
         return NoActiveOrderError.fromJson(json);
-      case 'Order':
+      case 'order':
         return Order.fromJson(json);
-      case 'OrderPaymentStateError':
+      case 'orderPaymentStateError':
         return OrderPaymentStateError.fromJson(json);
-      case 'OrderStateTransitionError':
+      case 'orderStateTransitionError':
         return OrderStateTransitionError.fromJson(json);
-      case 'PaymentDeclinedError':
+      case 'paymentDeclinedError':
         return PaymentDeclinedError.fromJson(json);
-      case 'PaymentFailedError':
+      case 'paymentFailedError':
         return PaymentFailedError.fromJson(json);
       default:
-        throw ArgumentError('Unknown AddPaymentToOrderResult variant: \$runtimeType');
+        throw ArgumentError('Unknown AddPaymentToOrderResult variant: $runtimeType');
     }
   }
 

--- a/lib/src/domain/entities/apply_coupon_code_result/apply_coupon_code_result.dart
+++ b/lib/src/domain/entities/apply_coupon_code_result/apply_coupon_code_result.dart
@@ -21,16 +21,16 @@ sealed class ApplyCouponCodeResult {
   factory ApplyCouponCodeResult.fromJson(Map<String, dynamic> json) {
     final runtimeType = json['runtimeType'] as String?;
     switch (runtimeType) {
-      case 'CouponCodeExpiredError':
+      case 'couponCodeExpiredError':
         return CouponCodeExpiredError.fromJson(json);
-      case 'CouponCodeInvalidError':
+      case 'couponCodeInvalidError':
         return CouponCodeInvalidError.fromJson(json);
-      case 'CouponCodeLimitError':
+      case 'couponCodeLimitError':
         return CouponCodeLimitError.fromJson(json);
-      case 'Order':
+      case 'order':
         return Order.fromJson(json);
       default:
-        throw ArgumentError('Unknown ApplyCouponCodeResult variant: \$runtimeType');
+        throw ArgumentError('Unknown ApplyCouponCodeResult variant: $runtimeType');
     }
   }
 

--- a/lib/src/domain/entities/authentication_result/authentication_result.dart
+++ b/lib/src/domain/entities/authentication_result/authentication_result.dart
@@ -10,14 +10,14 @@ sealed class AuthenticationResult {
   factory AuthenticationResult.fromJson(Map<String, dynamic> json) {
     final runtimeType = json['runtimeType'] as String?;
     switch (runtimeType) {
-      case 'CurrentUser':
+      case 'currentUser':
         return CurrentUser.fromJson(json);
-      case 'InvalidCredentialsError':
+      case 'invalidCredentialsError':
         return InvalidCredentialsError.fromJson(json);
-      case 'NotVerifiedError':
+      case 'notVerifiedError':
         return NotVerifiedError.fromJson(json);
       default:
-        throw ArgumentError('Unknown AuthenticationResult variant: \$runtimeType');
+        throw ArgumentError('Unknown AuthenticationResult variant: $runtimeType');
     }
   }
 

--- a/lib/src/domain/entities/custom_field_config/custom_field_config.dart
+++ b/lib/src/domain/entities/custom_field_config/custom_field_config.dart
@@ -11,26 +11,26 @@ sealed class CustomFieldConfig {
   factory CustomFieldConfig.fromJson(Map<String, dynamic> json) {
     final runtimeType = json['runtimeType'] as String?;
     switch (runtimeType) {
-      case 'BooleanCustomFieldConfig':
+      case 'booleanCustomFieldConfig':
         return BooleanCustomFieldConfig.fromJson(json);
-      case 'DateTimeCustomFieldConfig':
+      case 'dateTimeCustomFieldConfig':
         return DateTimeCustomFieldConfig.fromJson(json);
-      case 'FloatCustomFieldConfig':
+      case 'floatCustomFieldConfig':
         return FloatCustomFieldConfig.fromJson(json);
-      case 'IntCustomFieldConfig':
+      case 'intCustomFieldConfig':
         return IntCustomFieldConfig.fromJson(json);
-      case 'LocaleStringCustomFieldConfig':
+      case 'localeStringCustomFieldConfig':
         return LocaleStringCustomFieldConfig.fromJson(json);
-      case 'LocaleTextCustomFieldConfig':
+      case 'localeTextCustomFieldConfig':
         return LocaleTextCustomFieldConfig.fromJson(json);
-      case 'RelationCustomFieldConfig':
+      case 'relationCustomFieldConfig':
         return RelationCustomFieldConfig.fromJson(json);
-      case 'StringCustomFieldConfig':
+      case 'stringCustomFieldConfig':
         return StringCustomFieldConfig.fromJson(json);
-      case 'TextCustomFieldConfig':
+      case 'textCustomFieldConfig':
         return TextCustomFieldConfig.fromJson(json);
       default:
-        throw ArgumentError('Unknown CustomFieldConfig variant: \$runtimeType');
+        throw ArgumentError('Unknown CustomFieldConfig variant: $runtimeType');
     }
   }
 

--- a/lib/src/domain/entities/native_authentication_result/native_authentication_result.dart
+++ b/lib/src/domain/entities/native_authentication_result/native_authentication_result.dart
@@ -10,16 +10,16 @@ sealed class NativeAuthenticationResult {
   factory NativeAuthenticationResult.fromJson(Map<String, dynamic> json) {
     final runtimeType = json['runtimeType'] as String?;
     switch (runtimeType) {
-      case 'CurrentUser':
+      case 'currentUser':
         return CurrentUser.fromJson(json);
-      case 'InvalidCredentialsError':
+      case 'invalidCredentialsError':
         return InvalidCredentialsError.fromJson(json);
-      case 'NativeAuthStrategyError':
+      case 'nativeAuthStrategyError':
         return NativeAuthStrategyError.fromJson(json);
-      case 'NotVerifiedError':
+      case 'notVerifiedError':
         return NotVerifiedError.fromJson(json);
       default:
-        throw ArgumentError('Unknown NativeAuthenticationResult variant: \$runtimeType');
+        throw ArgumentError('Unknown NativeAuthenticationResult variant: $runtimeType');
     }
   }
 

--- a/lib/src/domain/entities/refresh_customer_verification_result/refresh_customer_verification_result.dart
+++ b/lib/src/domain/entities/refresh_customer_verification_result/refresh_customer_verification_result.dart
@@ -9,12 +9,12 @@ sealed class RefreshCustomerVerificationResult {
   factory RefreshCustomerVerificationResult.fromJson(Map<String, dynamic> json) {
     final runtimeType = json['runtimeType'] as String?;
     switch (runtimeType) {
-      case 'NativeAuthStrategyError':
+      case 'nativeAuthStrategyError':
         return NativeAuthStrategyError.fromJson(json);
-      case 'Success':
+      case 'success':
         return Success.fromJson(json);
       default:
-        throw ArgumentError('Unknown RefreshCustomerVerificationResult variant: \$runtimeType');
+        throw ArgumentError('Unknown RefreshCustomerVerificationResult variant: $runtimeType');
     }
   }
 

--- a/lib/src/domain/entities/register_customer_account_result/register_customer_account_result.dart
+++ b/lib/src/domain/entities/register_customer_account_result/register_customer_account_result.dart
@@ -9,16 +9,16 @@ sealed class RegisterCustomerAccountResult {
   factory RegisterCustomerAccountResult.fromJson(Map<String, dynamic> json) {
     final runtimeType = json['runtimeType'] as String?;
     switch (runtimeType) {
-      case 'MissingPasswordError':
+      case 'missingPasswordError':
         return MissingPasswordError.fromJson(json);
-      case 'NativeAuthStrategyError':
+      case 'nativeAuthStrategyError':
         return NativeAuthStrategyError.fromJson(json);
-      case 'PasswordValidationError':
+      case 'passwordValidationError':
         return PasswordValidationError.fromJson(json);
-      case 'Success':
+      case 'success':
         return Success.fromJson(json);
       default:
-        throw ArgumentError('Unknown RegisterCustomerAccountResult variant: \$runtimeType');
+        throw ArgumentError('Unknown RegisterCustomerAccountResult variant: $runtimeType');
     }
   }
 

--- a/lib/src/domain/entities/remove_order_items_result/remove_order_items_result.dart
+++ b/lib/src/domain/entities/remove_order_items_result/remove_order_items_result.dart
@@ -21,12 +21,12 @@ sealed class RemoveOrderItemsResult {
   factory RemoveOrderItemsResult.fromJson(Map<String, dynamic> json) {
     final runtimeType = json['runtimeType'] as String?;
     switch (runtimeType) {
-      case 'Order':
+      case 'order':
         return Order.fromJson(json);
-      case 'OrderModificationError':
+      case 'orderModificationError':
         return OrderModificationError.fromJson(json);
       default:
-        throw ArgumentError('Unknown RemoveOrderItemsResult variant: \$runtimeType');
+        throw ArgumentError('Unknown RemoveOrderItemsResult variant: $runtimeType');
     }
   }
 

--- a/lib/src/domain/entities/request_password_reset_result/request_password_reset_result.dart
+++ b/lib/src/domain/entities/request_password_reset_result/request_password_reset_result.dart
@@ -9,12 +9,12 @@ sealed class RequestPasswordResetResult {
   factory RequestPasswordResetResult.fromJson(Map<String, dynamic> json) {
     final runtimeType = json['runtimeType'] as String?;
     switch (runtimeType) {
-      case 'NativeAuthStrategyError':
+      case 'nativeAuthStrategyError':
         return NativeAuthStrategyError.fromJson(json);
-      case 'Success':
+      case 'success':
         return Success.fromJson(json);
       default:
-        throw ArgumentError('Unknown RequestPasswordResetResult variant: \$runtimeType');
+        throw ArgumentError('Unknown RequestPasswordResetResult variant: $runtimeType');
     }
   }
 

--- a/lib/src/domain/entities/request_update_customer_email_address_result/request_update_customer_email_address_result.dart
+++ b/lib/src/domain/entities/request_update_customer_email_address_result/request_update_customer_email_address_result.dart
@@ -9,16 +9,16 @@ sealed class RequestUpdateCustomerEmailAddressResult {
   factory RequestUpdateCustomerEmailAddressResult.fromJson(Map<String, dynamic> json) {
     final runtimeType = json['runtimeType'] as String?;
     switch (runtimeType) {
-      case 'EmailAddressConflictError':
+      case 'emailAddressConflictError':
         return EmailAddressConflictError.fromJson(json);
-      case 'InvalidCredentialsError':
+      case 'invalidCredentialsError':
         return InvalidCredentialsError.fromJson(json);
-      case 'NativeAuthStrategyError':
+      case 'nativeAuthStrategyError':
         return NativeAuthStrategyError.fromJson(json);
-      case 'Success':
+      case 'success':
         return Success.fromJson(json);
       default:
-        throw ArgumentError('Unknown RequestUpdateCustomerEmailAddressResult variant: \$runtimeType');
+        throw ArgumentError('Unknown RequestUpdateCustomerEmailAddressResult variant: $runtimeType');
     }
   }
 

--- a/lib/src/domain/entities/reset_password_result/reset_password_result.dart
+++ b/lib/src/domain/entities/reset_password_result/reset_password_result.dart
@@ -10,20 +10,20 @@ sealed class ResetPasswordResult {
   factory ResetPasswordResult.fromJson(Map<String, dynamic> json) {
     final runtimeType = json['runtimeType'] as String?;
     switch (runtimeType) {
-      case 'CurrentUser':
+      case 'currentUser':
         return CurrentUser.fromJson(json);
-      case 'NativeAuthStrategyError':
+      case 'nativeAuthStrategyError':
         return NativeAuthStrategyError.fromJson(json);
-      case 'NotVerifiedError':
+      case 'notVerifiedError':
         return NotVerifiedError.fromJson(json);
-      case 'PasswordResetTokenExpiredError':
+      case 'passwordResetTokenExpiredError':
         return PasswordResetTokenExpiredError.fromJson(json);
-      case 'PasswordResetTokenInvalidError':
+      case 'passwordResetTokenInvalidError':
         return PasswordResetTokenInvalidError.fromJson(json);
-      case 'PasswordValidationError':
+      case 'passwordValidationError':
         return PasswordValidationError.fromJson(json);
       default:
-        throw ArgumentError('Unknown ResetPasswordResult variant: \$runtimeType');
+        throw ArgumentError('Unknown ResetPasswordResult variant: $runtimeType');
     }
   }
 

--- a/lib/src/domain/entities/search_result_price/search_result_price.dart
+++ b/lib/src/domain/entities/search_result_price/search_result_price.dart
@@ -8,12 +8,12 @@ sealed class SearchResultPrice {
   factory SearchResultPrice.fromJson(Map<String, dynamic> json) {
     final runtimeType = json['runtimeType'] as String?;
     switch (runtimeType) {
-      case 'PriceRange':
+      case 'priceRange':
         return PriceRange.fromJson(json);
-      case 'SinglePrice':
+      case 'singlePrice':
         return SinglePrice.fromJson(json);
       default:
-        throw ArgumentError('Unknown SearchResultPrice variant: \$runtimeType');
+        throw ArgumentError('Unknown SearchResultPrice variant: $runtimeType');
     }
   }
 

--- a/lib/src/domain/entities/set_customer_for_order_result/set_customer_for_order_result.dart
+++ b/lib/src/domain/entities/set_customer_for_order_result/set_customer_for_order_result.dart
@@ -22,18 +22,18 @@ sealed class SetCustomerForOrderResult {
   factory SetCustomerForOrderResult.fromJson(Map<String, dynamic> json) {
     final runtimeType = json['runtimeType'] as String?;
     switch (runtimeType) {
-      case 'AlreadyLoggedInError':
+      case 'alreadyLoggedInError':
         return AlreadyLoggedInError.fromJson(json);
-      case 'EmailAddressConflictError':
+      case 'emailAddressConflictError':
         return EmailAddressConflictError.fromJson(json);
-      case 'GuestCheckoutError':
+      case 'guestCheckoutError':
         return GuestCheckoutError.fromJson(json);
-      case 'NoActiveOrderError':
+      case 'noActiveOrderError':
         return NoActiveOrderError.fromJson(json);
-      case 'Order':
+      case 'order':
         return Order.fromJson(json);
       default:
-        throw ArgumentError('Unknown SetCustomerForOrderResult variant: \$runtimeType');
+        throw ArgumentError('Unknown SetCustomerForOrderResult variant: $runtimeType');
     }
   }
 

--- a/lib/src/domain/entities/set_order_shipping_method_result/set_order_shipping_method_result.dart
+++ b/lib/src/domain/entities/set_order_shipping_method_result/set_order_shipping_method_result.dart
@@ -21,16 +21,16 @@ sealed class SetOrderShippingMethodResult {
   factory SetOrderShippingMethodResult.fromJson(Map<String, dynamic> json) {
     final runtimeType = json['runtimeType'] as String?;
     switch (runtimeType) {
-      case 'IneligibleShippingMethodError':
+      case 'ineligibleShippingMethodError':
         return IneligibleShippingMethodError.fromJson(json);
-      case 'NoActiveOrderError':
+      case 'noActiveOrderError':
         return NoActiveOrderError.fromJson(json);
-      case 'Order':
+      case 'order':
         return Order.fromJson(json);
-      case 'OrderModificationError':
+      case 'orderModificationError':
         return OrderModificationError.fromJson(json);
       default:
-        throw ArgumentError('Unknown SetOrderShippingMethodResult variant: \$runtimeType');
+        throw ArgumentError('Unknown SetOrderShippingMethodResult variant: $runtimeType');
     }
   }
 

--- a/lib/src/domain/entities/transition_order_to_state_result/transition_order_to_state_result.dart
+++ b/lib/src/domain/entities/transition_order_to_state_result/transition_order_to_state_result.dart
@@ -21,12 +21,12 @@ sealed class TransitionOrderToStateResult {
   factory TransitionOrderToStateResult.fromJson(Map<String, dynamic> json) {
     final runtimeType = json['runtimeType'] as String?;
     switch (runtimeType) {
-      case 'Order':
+      case 'order':
         return Order.fromJson(json);
-      case 'OrderStateTransitionError':
+      case 'orderStateTransitionError':
         return OrderStateTransitionError.fromJson(json);
       default:
-        throw ArgumentError('Unknown TransitionOrderToStateResult variant: \$runtimeType');
+        throw ArgumentError('Unknown TransitionOrderToStateResult variant: $runtimeType');
     }
   }
 

--- a/lib/src/domain/entities/update_customer_email_address_result/update_customer_email_address_result.dart
+++ b/lib/src/domain/entities/update_customer_email_address_result/update_customer_email_address_result.dart
@@ -9,16 +9,16 @@ sealed class UpdateCustomerEmailAddressResult {
   factory UpdateCustomerEmailAddressResult.fromJson(Map<String, dynamic> json) {
     final runtimeType = json['runtimeType'] as String?;
     switch (runtimeType) {
-      case 'IdentifierChangeTokenExpiredError':
+      case 'identifierChangeTokenExpiredError':
         return IdentifierChangeTokenExpiredError.fromJson(json);
-      case 'IdentifierChangeTokenInvalidError':
+      case 'identifierChangeTokenInvalidError':
         return IdentifierChangeTokenInvalidError.fromJson(json);
-      case 'NativeAuthStrategyError':
+      case 'nativeAuthStrategyError':
         return NativeAuthStrategyError.fromJson(json);
-      case 'Success':
+      case 'success':
         return Success.fromJson(json);
       default:
-        throw ArgumentError('Unknown UpdateCustomerEmailAddressResult variant: \$runtimeType');
+        throw ArgumentError('Unknown UpdateCustomerEmailAddressResult variant: $runtimeType');
     }
   }
 

--- a/lib/src/domain/entities/update_customer_password_result/update_customer_password_result.dart
+++ b/lib/src/domain/entities/update_customer_password_result/update_customer_password_result.dart
@@ -9,16 +9,16 @@ sealed class UpdateCustomerPasswordResult {
   factory UpdateCustomerPasswordResult.fromJson(Map<String, dynamic> json) {
     final runtimeType = json['runtimeType'] as String?;
     switch (runtimeType) {
-      case 'InvalidCredentialsError':
+      case 'invalidCredentialsError':
         return InvalidCredentialsError.fromJson(json);
-      case 'NativeAuthStrategyError':
+      case 'nativeAuthStrategyError':
         return NativeAuthStrategyError.fromJson(json);
-      case 'PasswordValidationError':
+      case 'passwordValidationError':
         return PasswordValidationError.fromJson(json);
-      case 'Success':
+      case 'success':
         return Success.fromJson(json);
       default:
-        throw ArgumentError('Unknown UpdateCustomerPasswordResult variant: \$runtimeType');
+        throw ArgumentError('Unknown UpdateCustomerPasswordResult variant: $runtimeType');
     }
   }
 

--- a/lib/src/domain/entities/update_order_items_result/update_order_items_result.dart
+++ b/lib/src/domain/entities/update_order_items_result/update_order_items_result.dart
@@ -21,18 +21,18 @@ sealed class UpdateOrderItemsResult {
   factory UpdateOrderItemsResult.fromJson(Map<String, dynamic> json) {
     final runtimeType = json['runtimeType'] as String?;
     switch (runtimeType) {
-      case 'InsufficientStockError':
+      case 'insufficientStockError':
         return InsufficientStockError.fromJson(json);
-      case 'NegativeQuantityError':
+      case 'negativeQuantityError':
         return NegativeQuantityError.fromJson(json);
-      case 'Order':
+      case 'order':
         return Order.fromJson(json);
-      case 'OrderLimitError':
+      case 'orderLimitError':
         return OrderLimitError.fromJson(json);
-      case 'OrderModificationError':
+      case 'orderModificationError':
         return OrderModificationError.fromJson(json);
       default:
-        throw ArgumentError('Unknown UpdateOrderItemsResult variant: \$runtimeType');
+        throw ArgumentError('Unknown UpdateOrderItemsResult variant: $runtimeType');
     }
   }
 

--- a/lib/src/domain/entities/verify_customer_account_result/verify_customer_account_result.dart
+++ b/lib/src/domain/entities/verify_customer_account_result/verify_customer_account_result.dart
@@ -10,22 +10,22 @@ sealed class VerifyCustomerAccountResult {
   factory VerifyCustomerAccountResult.fromJson(Map<String, dynamic> json) {
     final runtimeType = json['runtimeType'] as String?;
     switch (runtimeType) {
-      case 'CurrentUser':
+      case 'currentUser':
         return CurrentUser.fromJson(json);
-      case 'MissingPasswordError':
+      case 'missingPasswordError':
         return MissingPasswordError.fromJson(json);
-      case 'NativeAuthStrategyError':
+      case 'nativeAuthStrategyError':
         return NativeAuthStrategyError.fromJson(json);
-      case 'PasswordAlreadySetError':
+      case 'passwordAlreadySetError':
         return PasswordAlreadySetError.fromJson(json);
-      case 'PasswordValidationError':
+      case 'passwordValidationError':
         return PasswordValidationError.fromJson(json);
-      case 'VerificationTokenExpiredError':
+      case 'verificationTokenExpiredError':
         return VerificationTokenExpiredError.fromJson(json);
-      case 'VerificationTokenInvalidError':
+      case 'verificationTokenInvalidError':
         return VerificationTokenInvalidError.fromJson(json);
       default:
-        throw ArgumentError('Unknown VerifyCustomerAccountResult variant: \$runtimeType');
+        throw ArgumentError('Unknown VerifyCustomerAccountResult variant: $runtimeType');
     }
   }
 

--- a/lib/src/vendure/custom_operations.dart
+++ b/lib/src/vendure/custom_operations.dart
@@ -1,119 +1,23 @@
 import 'package:graphql/client.dart';
+import 'package:vendure/data/datasources/remote/vendure_remote_datasource.dart';
 import 'package:vendure/src/input_types/paginated_list.dart';
 import 'package:vendure/src/vendure/operation_type_enum.dart';
 import 'package:vendure/src/vendure/vendure_utils.dart';
 
 class CustomOperations {
-  final Future<GraphQLClient> Function() _client;
-  final Map<String, List<dynamic>>? customFieldsConfig;
+  final VendureRemoteDataSource _dataSource;
 
-  CustomOperations(this._client, {this.customFieldsConfig});
+  CustomOperations(
+    Future<GraphQLClient> Function() client, {
+    Map<String, List<dynamic>>? customFieldsConfig,
+  }) : _dataSource = VendureRemoteDataSource(
+          getClient: client,
+          customFieldsConfig: customFieldsConfig,
+        );
 
-  String _prepareOperation(String operation) {
-    if (customFieldsConfig != null) {
-      return VendureUtils.sanitizeGraphQLQuery(operation, customFieldsConfig!);
-    }
-    return operation;
-  }
-
-  Future<T> _executeGraphQLOperation<T>(
-    String operation,
-    Map<String, dynamic> variables,
-    bool isMutation,
-    String? expectedDataType, {
-    bool convertEnums = false,
-  }) async {
-    final processedOperation = _prepareOperation(operation);
-    // VendureUtils.printLongString(processedOperation);
-    final client = await _client();
-
-    // Normalize variables for mutations (convert enums to CAPITAL_SNAKE_CASE) if enabled
-    final normalizedVariables = isMutation || convertEnums
-        ? VendureUtils.normalizeMutationData(
-            variables,
-            convertEnums: convertEnums,
-          )
-        : variables;
-
-    final options = isMutation
-        ? MutationOptions(
-            document: gql(processedOperation),
-            variables: normalizedVariables,
-          )
-        : QueryOptions(
-            document: gql(processedOperation),
-            variables: normalizedVariables,
-          );
-
-    final result = isMutation
-        ? await client.mutate(options as MutationOptions)
-        : await client.query(options as QueryOptions);
-
-    return _handleErrors(result, expectedDataType);
-  }
-
-  dynamic _handleErrors(QueryResult<Object?> result, String? expectedDataType) {
-    if (result.hasException) {
-      throw Exception(result.exception.toString());
-    }
-
-    dynamic data = result.data;
-    if (data == null) {
-      throw Exception('No data returned from GraphQL operation');
-    }
-
-    data = _extractExpectedData(data, expectedDataType);
-    if (data == null) {
-      throw Exception('No data returned for expected type: $expectedDataType');
-    }
-
-    if (data is Map && data['__typename'] == 'ErrorResult') {
-      throw Exception(data['message']);
-    }
-
-    return data;
-  }
-
-  dynamic _extractExpectedData(dynamic data, String? expectedDataType) {
-    if (expectedDataType == null || data == null) {
-      return data;
-    }
-
-    if (expectedDataType.contains('.')) {
-      var currentData = data;
-      final parts = expectedDataType.split('.');
-      for (var part in parts) {
-        if (currentData is Map<String, dynamic>) {
-          currentData = currentData[part];
-        } else {
-          return null;
-        }
-        if (currentData == null) {
-          return null;
-        }
-      }
-      return currentData;
-    }
-
-    if (data is Map<String, dynamic>) {
-      return data[expectedDataType];
-    }
-    return null;
-  }
-
-  Map<String, dynamic> _extractHeadersFromResponse(
-    QueryResult<Object?> response,
-    List<String> headers,
-  ) {
-    final context = response.context.entry<HttpLinkResponseContext>()?.headers;
-    Map<String, dynamic>? result = {};
-    context?.forEach((key, value) {
-      if (headers.contains(key)) {
-        result[key] = value;
-      }
-    });
-    return result;
-  }
+  /// Direct access to the underlying data source, if needed by advanced
+  /// callers that need to bypass the convenience wrappers.
+  VendureRemoteDataSource get dataSource => _dataSource;
 
   Future<T> mutate<T>(
     String mutation,
@@ -121,32 +25,14 @@ class CustomOperations {
     T Function(Map<String, dynamic>)? fromJson,
     String? expectedDataType,
     bool convertEnums = true,
-  }) async {
-    var data = await _executeGraphQLOperation(
+  }) {
+    return _dataSource.mutate<T>(
       mutation,
       variables,
-      true,
-      expectedDataType,
+      fromJson: fromJson,
+      expectedDataType: expectedDataType,
       convertEnums: convertEnums,
     );
-
-    if (data == null) {
-      throw Exception('No data returned from mutate');
-    }
-
-    if (data is Map || data is List) {
-      data = VendureUtils.normalizeGraphQLData(
-        data,
-        convertEnums: convertEnums,
-      );
-    }
-    if (fromJson != null) {
-      if (data is! Map) {
-        throw Exception('Expected map data but got ${data.runtimeType}');
-      }
-      return fromJson(Map<String, dynamic>.from(data));
-    }
-    return data;
   }
 
   Future<T> query<T>(
@@ -155,31 +41,14 @@ class CustomOperations {
     T Function(Map<String, dynamic>)? fromJson,
     String? expectedDataType,
     bool convertEnums = false,
-  }) async {
-    var data = await _executeGraphQLOperation(
+  }) {
+    return _dataSource.query<T>(
       query,
       variables,
-      false,
-      expectedDataType,
+      fromJson: fromJson,
+      expectedDataType: expectedDataType,
       convertEnums: convertEnums,
     );
-
-    if (data == null) {
-      throw Exception('No data returned from query');
-    }
-    if (data is Map || data is List) {
-      data = VendureUtils.normalizeGraphQLData(
-        data,
-        convertEnums: convertEnums,
-      );
-    }
-    if (fromJson != null) {
-      if (data is! Map) {
-        throw Exception('Expected map data but got ${data.runtimeType}');
-      }
-      return fromJson(Map<String, dynamic>.from(data));
-    }
-    return data;
   }
 
   Future<List<T>> queryList<T>(
@@ -188,29 +57,14 @@ class CustomOperations {
     T Function(Map<String, dynamic>)? fromJson,
     String? expectedDataType,
     bool convertEnums = false,
-  }) async {
-    var data = await _executeGraphQLOperation(
+  }) {
+    return _dataSource.queryList<T>(
       query,
       variables,
-      false,
-      expectedDataType,
+      fromJson: fromJson,
+      expectedDataType: expectedDataType,
       convertEnums: convertEnums,
     );
-
-    if (data == null) {
-      throw Exception('No data returned from queryList');
-    }
-
-    if (data is! List) {
-      throw Exception('Data must be a list in queryList');
-    }
-
-    if (fromJson != null) {
-      return data.map<T>((item) {
-        return fromJson(item);
-      }).toList();
-    }
-    return List<T>.from(data);
   }
 
   Future<List<T>> mutateList<T>(
@@ -219,29 +73,14 @@ class CustomOperations {
     T Function(Map<String, dynamic>)? fromJson,
     String? expectedDataType,
     bool convertEnums = false,
-  }) async {
-    var data = await _executeGraphQLOperation(
+  }) {
+    return _dataSource.mutateList<T>(
       mutation,
       variables,
-      true,
-      expectedDataType,
+      fromJson: fromJson,
+      expectedDataType: expectedDataType,
       convertEnums: convertEnums,
     );
-
-    if (data == null) {
-      throw Exception('No data returned from mutateList');
-    }
-
-    if (data is! List) {
-      throw Exception('Data must be a list in mutateList');
-    }
-
-    if (fromJson != null) {
-      return data.map<T>((item) {
-        return fromJson(item);
-      }).toList();
-    }
-    return List<T>.from(data);
   }
 
   Future<PaginatedList<T>> queryListPaginated<T>(
@@ -253,8 +92,10 @@ class CustomOperations {
   }) async {
     final Map<String, dynamic> combinedVariables = {
       if (options != null) ...{
-        'filter': options.filter != null ? options.toJson()['filter'] : null,
-        'sort': options.sort != null ? options.toJson()['sort'] : null,
+        'filter':
+            options.filter != null ? options.toJson()['filter'] : null,
+        'sort':
+            options.sort != null ? options.toJson()['sort'] : null,
         'pagination': {
           if (options.take != null) 'take': options.take,
           if (options.skip != null) 'skip': options.skip,
@@ -262,11 +103,10 @@ class CustomOperations {
       },
     };
 
-    var data = await _executeGraphQLOperation(
+    var data = await _dataSource.query<dynamic>(
       query,
       combinedVariables,
-      false,
-      expectedDataType,
+      expectedDataType: expectedDataType,
       convertEnums: convertEnums,
     );
 
@@ -283,19 +123,16 @@ class CustomOperations {
 
     if (data is! Map) {
       throw Exception(
-        'Expected map data for PaginatedList but got ${data.runtimeType}',
-      );
+          'Expected map data for PaginatedList but got ${data.runtimeType}');
     }
 
     final items =
         (data['items'] as List?)
-            ?.map(
-              (item) => fromJson(
-                item is Map<String, dynamic>
-                    ? Map<String, dynamic>.from(item)
-                    : item,
-              ),
-            )
+            ?.map((item) => fromJson(
+                  item is Map<String, dynamic>
+                      ? Map<String, dynamic>.from(item)
+                      : item,
+                ))
             .toList() ??
         [];
     final totalItems = (data['totalItems'] as num?)?.toInt() ?? 0;
@@ -314,8 +151,10 @@ class CustomOperations {
     final Map<String, dynamic> combinedVariables = {
       ...variables,
       if (options != null) ...{
-        'filter': options.filter != null ? options.toJson()['filter'] : null,
-        'sort': options.sort != null ? options.toJson()['sort'] : null,
+        'filter':
+            options.filter != null ? options.toJson()['filter'] : null,
+        'sort':
+            options.sort != null ? options.toJson()['sort'] : null,
         'pagination': {
           if (options.take != null) 'take': options.take,
           if (options.skip != null) 'skip': options.skip,
@@ -323,11 +162,10 @@ class CustomOperations {
       },
     };
 
-    var data = await _executeGraphQLOperation(
+    var data = await _dataSource.mutate<dynamic>(
       mutation,
       combinedVariables,
-      true,
-      expectedDataType,
+      expectedDataType: expectedDataType,
       convertEnums: convertEnums,
     );
 
@@ -344,8 +182,7 @@ class CustomOperations {
 
     if (data is! Map) {
       throw Exception(
-        'Expected map data for PaginatedList but got ${data.runtimeType}',
-      );
+          'Expected map data for PaginatedList but got ${data.runtimeType}');
     }
 
     final items =
@@ -365,13 +202,50 @@ class CustomOperations {
     List<String> headers, {
     bool convertEnums = true,
   }) async {
-    final result = await _executeGraphQLOperation(
-      operation,
-      variables,
-      operationType == OperationType.mutation,
-      null,
-      convertEnums: convertEnums,
-    );
+    // extractResponseHeaders needs the raw QueryResult to pull headers
+    // from the HTTP link context, so we execute via the datasource's client
+    // and extract headers ourselves.
+    final client = await _dataSource.getClient();
+    final processedOperation = _dataSource.customFieldsConfig != null
+        ? VendureUtils.sanitizeGraphQLQuery(
+            operation, _dataSource.customFieldsConfig!)
+        : operation;
+
+    final isMutation = operationType == OperationType.mutation;
+    final normalizedVariables = isMutation || convertEnums
+        ? VendureUtils.normalizeMutationData(
+            variables, convertEnums: convertEnums)
+        : variables;
+
+    final options = isMutation
+        ? MutationOptions(
+            document: gql(processedOperation),
+            variables: normalizedVariables,
+          )
+        : QueryOptions(
+            document: gql(processedOperation),
+            variables: normalizedVariables,
+          );
+
+    final result = isMutation
+        ? await client.mutate(options as MutationOptions)
+        : await client.query(options as QueryOptions);
+
     return _extractHeadersFromResponse(result, headers);
+  }
+
+  Map<String, dynamic> _extractHeadersFromResponse(
+    QueryResult<Object?> response,
+    List<String> headers,
+  ) {
+    final context =
+        response.context.entry<HttpLinkResponseContext>()?.headers;
+    Map<String, dynamic> result = {};
+    context?.forEach((key, value) {
+      if (headers.contains(key)) {
+        result[key] = value;
+      }
+    });
+    return result;
   }
 }

--- a/test/comprehensive_user_journey_test.dart
+++ b/test/comprehensive_user_journey_test.dart
@@ -37,12 +37,12 @@ void main() {
         var products = await vendure.catalog.getProducts();
         expect(products.items, isNotEmpty);
 
-        var productWithVariants = products.items.firstWhere(
-          (p) => p.variants.isNotEmpty,
-          orElse: () => products.items.first,
+        var productWithVariants = products.items!.firstWhere(
+          (p) => p.variants!.isNotEmpty,
+          orElse: () => products.items!.first,
         );
 
-        testProductVariantId = productWithVariants.variants.first.id;
+        testProductVariantId = productWithVariants.variants!.first!.id!;
         print('✅ Found test product variant: ${productWithVariants.name}');
         print('📋 Variant ID: $testProductVariantId');
       } catch (e) {
@@ -93,7 +93,7 @@ void main() {
         expect(token, isNotNull);
         expect(token, isA<String>());
         print('✅ Token retrieved successfully');
-        print('📋 Token: ${token!.substring(0, 20)}...');
+        print('📋 Token: ${token!.substring!(0, 20)}...');
       } catch (e) {
         fail('❌ Token fetch failed: $e');
       }
@@ -111,7 +111,7 @@ void main() {
         expect(authenticatedVendure, isA<Vendure>());
         expect(authenticatedVendure.token, isNotNull);
         print('✅ Native auth initialization successful');
-        print('📋 Token: ${authenticatedVendure.token?.substring(0, 20)}...');
+        print('📋 Token: ${authenticatedVendure.token?.substring!(0, 20)}...');
       } catch (e) {
         fail('❌ Native auth initialization failed: $e');
       }
@@ -127,7 +127,7 @@ void main() {
       } catch (e) {
         String errorMsg = e.toString();
         print(
-          '✅ Correctly rejected invalid credentials: ${errorMsg.length > 100 ? '${errorMsg.substring(0, 100)}...' : errorMsg}',
+          '✅ Correctly rejected invalid credentials: ${errorMsg.length! > 100 ? '${errorMsg.substring!(0, 100)}...' : errorMsg}',
         );
       }
     });
@@ -142,7 +142,7 @@ void main() {
       } catch (e) {
         String errorMsg = e.toString();
         print(
-          '✅ Correctly rejected invalid login: ${errorMsg.length > 100 ? '${errorMsg.substring(0, 100)}...' : errorMsg}',
+          '✅ Correctly rejected invalid login: ${errorMsg.length! > 100 ? '${errorMsg.substring!(0, 100)}...' : errorMsg}',
         );
       }
     });
@@ -198,8 +198,8 @@ void main() {
         Order order = Order.fromJson(result.toJson());
         expect(order.lines, isNotEmpty);
 
-        testOrderCode = order.code;
-        testOrderLineId = order.lines.first.id;
+        testOrderCode = order.code!;
+        testOrderLineId = order.lines!.first!.id!;
 
         print('✅ Added item to guest order');
         print('📋 Order code: $testOrderCode');
@@ -218,7 +218,7 @@ void main() {
 
         print('✅ Retrieved active order');
         print('📋 Order state: ${order.state}');
-        print('📋 Line count: ${order.lines.length}');
+        print('📋 Line count: ${order.lines!.length}');
       } catch (e) {
         fail('❌ Failed to get active order: $e');
       }
@@ -233,10 +233,10 @@ void main() {
 
         expect(result, isA<UpdateOrderItemsResult>());
         Order order = Order.fromJson(result.toJson());
-        expect(order.lines.first.quantity, equals(3));
+        expect(order.lines!.first!.quantity, equals(3));
 
         print('✅ Adjusted order line quantity');
-        print('📋 New quantity: ${order.lines.first.quantity}');
+        print('📋 New quantity: ${order.lines!.first!.quantity}');
       } catch (e) {
         fail('❌ Failed to adjust order line: $e');
       }
@@ -277,7 +277,7 @@ void main() {
       } catch (e) {
         String errorMsg = e.toString();
         print(
-          '✅ Correctly handled invalid coupon: ${errorMsg.length > 100 ? '${errorMsg.substring(0, 100)}...' : errorMsg}',
+          '✅ Correctly handled invalid coupon: ${errorMsg.length! > 100 ? '${errorMsg.substring!(0, 100)}...' : errorMsg}',
         );
       }
     });
@@ -291,7 +291,7 @@ void main() {
       } catch (e) {
         String errorMsg = e.toString();
         print(
-          '⚠️ No valid coupons available: ${errorMsg.length > 100 ? '${errorMsg.substring(0, 100)}...' : errorMsg}',
+          '⚠️ No valid coupons available: ${errorMsg.length! > 100 ? '${errorMsg.substring!(0, 100)}...' : errorMsg}',
         );
       }
     });
@@ -332,8 +332,8 @@ void main() {
 
         expect(result, isA<UpdateOrderItemsResult>());
         Order order = Order.fromJson(result.toJson());
-        testOrderCode = order.code;
-        testOrderLineId = order.lines.first.id;
+        testOrderCode = order.code!;
+        testOrderLineId = order.lines!.first!.id!;
 
         print('✅ Added item back for shipping tests');
       } catch (e) {
@@ -348,14 +348,14 @@ void main() {
         var countries = await vendure.system.getAvailableCountries();
         expect(countries, isNotEmpty);
 
-        print('✅ Retrieved ${countries.length} countries');
+        print('✅ Retrieved ${countries.length!} countries');
 
         // Find US for address testing
         var usCountry = countries.firstWhere(
           (c) => c.code == 'US',
           orElse: () => countries.first,
         );
-        testCountryCode = usCountry.code;
+        testCountryCode = usCountry.code!;
         print('📋 Using country: ${usCountry.name} (${usCountry.code})');
       } catch (e) {
         fail('❌ Failed to get countries: $e');
@@ -368,8 +368,8 @@ void main() {
         expect(facets, isA<FacetList>());
 
         print('✅ Retrieved ${facets.totalItems} facets');
-        if (facets.items.isNotEmpty) {
-          print('📋 Sample facet: ${facets.items.first.name}');
+        if (facets.items!.isNotEmpty) {
+          print('📋 Sample facet: ${facets.items!.first!.name}');
         }
       } catch (e) {
         fail('❌ Failed to get facets: $e');
@@ -379,12 +379,12 @@ void main() {
     test('Get specific facet by ID', () async {
       try {
         var facets = await vendure.system.getFacets();
-        if (facets.items.isNotEmpty) {
-          var facet = await vendure.system.getFacet(id: facets.items.first.id);
+        if (facets.items!.isNotEmpty) {
+          var facet = await vendure.system.getFacet(id: facets.items!.first!.id!);
           expect(facet, isA<Facet>());
 
           print('✅ Retrieved specific facet: ${facet.name}');
-          print('📋 Facet values: ${facet.values?.length ?? 0}');
+          print('📋 Facet values: ${facet.values?.length! ?? 0}');
         }
       } catch (e) {
         print('⚠️ Failed to get specific facet: $e');
@@ -417,9 +417,9 @@ void main() {
     test('Get collection by ID', () async {
       try {
         var collections = await vendure.catalog.getCollections();
-        if (collections.items.isNotEmpty) {
+        if (collections.items!.isNotEmpty) {
           var collection = await vendure.catalog.getCollectionById(
-            id: collections.items.first.id,
+            id: collections.items!.first!.id!,
           );
 
           expect(collection, isA<Collection>());
@@ -433,10 +433,10 @@ void main() {
     test('Get collection by slug', () async {
       try {
         var collections = await vendure.catalog.getCollections();
-        if (collections.items.isNotEmpty) {
-          var firstCollection = collections.items.first;
+        if (collections.items!.isNotEmpty) {
+          var firstCollection = collections.items!.first;
           var collection = await vendure.catalog.getCollectionBySlug(
-            slug: firstCollection.slug,
+            slug: firstCollection.slug!,
           );
 
           expect(collection, isA<Collection>());
@@ -461,14 +461,14 @@ void main() {
     test('Get product by ID', () async {
       try {
         var products = await vendure.catalog.getProducts();
-        if (products.items.isNotEmpty) {
+        if (products.items!.isNotEmpty) {
           var product = await vendure.catalog.getProductById(
-            id: products.items.first.id,
+            id: products.items!.first!.id!,
           );
 
           expect(product, isA<Product>());
           print('✅ Retrieved product by ID: ${product.name}');
-          print('📋 Variants: ${product.variants.length}');
+          print('📋 Variants: ${product.variants!.length}');
         }
       } catch (e) {
         fail('❌ Failed to get product by ID: $e');
@@ -478,10 +478,10 @@ void main() {
     test('Get product by slug', () async {
       try {
         var products = await vendure.catalog.getProducts();
-        if (products.items.isNotEmpty) {
-          var firstProduct = products.items.first;
+        if (products.items!.isNotEmpty) {
+          var firstProduct = products.items!.first;
           var product = await vendure.catalog.getProductBySlug(
-            slug: firstProduct.slug,
+            slug: firstProduct.slug!,
           );
 
           expect(product, isA<Product>());
@@ -522,7 +522,7 @@ void main() {
 
         expect(result, isA<SearchResponse>());
         print('✅ Search with filters: ${result.totalItems} results');
-        print('📋 Facet values: ${result.facetValues.length}');
+        print('📋 Facet values: ${result.facetValues!.length}');
       } catch (e) {
         print('⚠️ Search with filters failed: $e');
       }
@@ -575,7 +575,7 @@ void main() {
         var shippingMethods = await vendure.order.getShippingMethods();
         expect(shippingMethods, isA<List<ShippingMethodQuote>>());
 
-        print('✅ Retrieved ${shippingMethods.length} shipping methods');
+        print('✅ Retrieved ${shippingMethods.length!} shipping methods');
 
         if (shippingMethods.isNotEmpty) {
           print(
@@ -585,11 +585,11 @@ void main() {
           // Set the first shipping method
           try {
             var result = await vendure.order.setOrderShippingMethod(
-              shippingMethodId: shippingMethods.first.id,
+              shippingMethodId: shippingMethods!.first!.id!,
             );
 
             expect(result, isA<SetOrderShippingMethodResult>());
-            print('✅ Set shipping method: ${shippingMethods.first.name}');
+            print('✅ Set shipping method: ${shippingMethods!.first!.name}');
           } catch (e) {
             print('⚠️ Failed to set shipping method: $e');
           }
@@ -604,7 +604,7 @@ void main() {
         var paymentMethods = await vendure.order.getPaymentMethods();
         expect(paymentMethods, isA<List<PaymentMethodQuote>>());
 
-        print('✅ Retrieved ${paymentMethods.length} payment methods');
+        print('✅ Retrieved ${paymentMethods.length!} payment methods');
         if (paymentMethods.isNotEmpty) {
           print(
             '📋 Available methods: ${paymentMethods.map((m) => m.name).join(", ")}',
@@ -620,7 +620,7 @@ void main() {
         var states = await vendure.order.getNextOrderStates();
         expect(states, isA<List<String>>());
 
-        print('✅ Retrieved ${states.length} next order states');
+        print('✅ Retrieved ${states.length!} next order states');
         if (states.isNotEmpty) {
           print('📋 Next states: ${states.join(", ")}');
         }
@@ -680,7 +680,7 @@ void main() {
         );
 
         expect(result, isA<Customer>());
-        expect(result.firstName, equals('Updated'));
+        expect(result.firstName!, equals('Updated'));
         print('✅ Updated customer details');
         print('📋 New name: ${result.firstName} ${result.lastName}');
       } catch (e) {
@@ -702,7 +702,7 @@ void main() {
         );
 
         expect(result, isA<Address>());
-        testAddressId = result.id;
+        testAddressId = result.id!;
         print('✅ Created customer address');
         print('📋 Address ID: ${result.id}');
       } catch (e) {
@@ -757,8 +757,8 @@ void main() {
         Order order = Order.fromJson(result.toJson());
         expect(order.lines, isNotEmpty);
 
-        testOrderCode = order.code;
-        testOrderLineId = order.lines.first.id;
+        testOrderCode = order.code!;
+        testOrderLineId = order.lines!.first!.id!;
 
         print('✅ Added item to authenticated order');
         print('📋 Order code: $testOrderCode');
@@ -829,19 +829,19 @@ void main() {
         expect(shippingMethods, isA<List<ShippingMethodQuote>>());
 
         print(
-          '✅ Retrieved ${shippingMethods.length} shipping methods for authenticated order',
+          '✅ Retrieved ${shippingMethods.length!} shipping methods for authenticated order',
         );
 
         if (shippingMethods.isNotEmpty) {
           try {
             var result = await authenticatedVendure.order
                 .setOrderShippingMethod(
-                  shippingMethodId: shippingMethods.first.id,
+                  shippingMethodId: shippingMethods!.first!.id!,
                 );
 
             expect(result, isA<SetOrderShippingMethodResult>());
             print(
-              '✅ Set shipping method for authenticated order: ${shippingMethods.first.name}',
+              '✅ Set shipping method for authenticated order: ${shippingMethods!.first!.name}',
             );
           } catch (e) {
             print(
@@ -861,7 +861,7 @@ void main() {
         expect(paymentMethods, isA<List<PaymentMethodQuote>>());
 
         print(
-          '✅ Retrieved ${paymentMethods.length} payment methods for authenticated order',
+          '✅ Retrieved ${paymentMethods.length!} payment methods for authenticated order',
         );
         if (paymentMethods.isNotEmpty) {
           print(
@@ -972,7 +972,7 @@ void main() {
       } catch (e) {
         String errorMsg = e.toString();
         print(
-          '✅ Correctly handled invalid variant: ${errorMsg.length > 100 ? '${errorMsg.substring(0, 100)}...' : errorMsg}',
+          '✅ Correctly handled invalid variant: ${errorMsg.length! > 100 ? '${errorMsg.substring!(0, 100)}...' : errorMsg}',
         );
       }
     });
@@ -984,7 +984,7 @@ void main() {
       } catch (e) {
         String errorMsg = e.toString();
         print(
-          '✅ Correctly handled invalid order line: ${errorMsg.length > 100 ? '${errorMsg.substring(0, 100)}...' : errorMsg}',
+          '✅ Correctly handled invalid order line: ${errorMsg.length! > 100 ? '${errorMsg.substring!(0, 100)}...' : errorMsg}',
         );
       }
     });
@@ -996,7 +996,7 @@ void main() {
       } catch (e) {
         String errorMsg = e.toString();
         print(
-          '✅ Correctly handled invalid collection: ${errorMsg.length > 100 ? '${errorMsg.substring(0, 100)}...' : errorMsg}',
+          '✅ Correctly handled invalid collection: ${errorMsg.length! > 100 ? '${errorMsg.substring!(0, 100)}...' : errorMsg}',
         );
       }
     });
@@ -1008,7 +1008,7 @@ void main() {
       } catch (e) {
         String errorMsg = e.toString();
         print(
-          '✅ Correctly handled invalid product: ${errorMsg.length > 100 ? '${errorMsg.substring(0, 100)}...' : errorMsg}',
+          '✅ Correctly handled invalid product: ${errorMsg.length! > 100 ? '${errorMsg.substring!(0, 100)}...' : errorMsg}',
         );
       }
     });
@@ -1028,7 +1028,7 @@ void main() {
       } catch (e) {
         String errorMsg = e.toString();
         print(
-          '✅ Correctly handled invalid country: ${errorMsg.length > 100 ? '${errorMsg.substring(0, 100)}...' : errorMsg}',
+          '✅ Correctly handled invalid country: ${errorMsg.length! > 100 ? '${errorMsg.substring!(0, 100)}...' : errorMsg}',
         );
       }
     });
@@ -1043,7 +1043,7 @@ void main() {
       } catch (e) {
         String errorMsg = e.toString();
         print(
-          '✅ Correctly handled negative quantity: ${errorMsg.length > 100 ? '${errorMsg.substring(0, 100)}...' : errorMsg}',
+          '✅ Correctly handled negative quantity: ${errorMsg.length! > 100 ? '${errorMsg.substring!(0, 100)}...' : errorMsg}',
         );
       }
     });
@@ -1058,7 +1058,7 @@ void main() {
       } catch (e) {
         String errorMsg = e.toString();
         print(
-          '✅ Correctly handled zero quantity: ${errorMsg.length > 100 ? '${errorMsg.substring(0, 100)}...' : errorMsg}',
+          '✅ Correctly handled zero quantity: ${errorMsg.length! > 100 ? '${errorMsg.substring!(0, 100)}...' : errorMsg}',
         );
       }
     });

--- a/test/fresh_vendure_store_test.dart
+++ b/test/fresh_vendure_store_test.dart
@@ -34,7 +34,7 @@ void main() {
         var countries = await vendure.system.getAvailableCountries();
         expect(countries, isA<List<Country>>());
         expect(countries, isNotEmpty);
-        print('✅ Retrieved ${countries.length} available countries');
+        print('✅ Retrieved ${countries.length!} available countries');
         print(
           '📋 Sample countries: ${countries.take(3).map((c) => c.name).join(", ")}',
         );
@@ -48,8 +48,8 @@ void main() {
         var collections = await vendure.catalog.getCollections();
         expect(collections, isA<CollectionList>());
         print('✅ Retrieved ${collections.totalItems} collections');
-        if (collections.items.isNotEmpty) {
-          print('📋 Sample collection: ${collections.items.first.name}');
+        if (collections.items!.isNotEmpty) {
+          print('📋 Sample collection: ${collections.items!.first!.name}');
         }
       } catch (e) {
         fail('❌ Failed to get collections: $e');
@@ -61,8 +61,8 @@ void main() {
         var products = await vendure.catalog.getProducts();
         expect(products, isA<ProductList>());
         print('✅ Retrieved ${products.totalItems} products');
-        if (products.items.isNotEmpty) {
-          print('📋 Sample product: ${products.items.first.name}');
+        if (products.items!.isNotEmpty) {
+          print('📋 Sample product: ${products.items!.first!.name}');
         }
       } catch (e) {
         fail('❌ Failed to get products: $e');
@@ -74,8 +74,8 @@ void main() {
         var facets = await vendure.system.getFacets();
         expect(facets, isA<FacetList>());
         print('✅ Retrieved ${facets.totalItems} facets');
-        if (facets.items.isNotEmpty) {
-          print('📋 Sample facet: ${facets.items.first.name}');
+        if (facets.items!.isNotEmpty) {
+          print('📋 Sample facet: ${facets.items!.first!.name}');
         }
       } catch (e) {
         fail('❌ Failed to get facets: $e');
@@ -170,7 +170,7 @@ void main() {
         if (token != null) {
           expect(token, isA<String>());
           print('✅ Token retrieved successfully');
-          print('📋 Token: ${token.substring(0, 20)}...');
+          print('📋 Token: ${token.substring!(0, 20)}...');
         } else {
           print('⚠️ Token is null - authentication may have failed');
         }
@@ -191,7 +191,7 @@ void main() {
         expect(authenticatedVendure, isA<Vendure>());
         expect(authenticatedVendure.token, isNotNull);
         print('✅ Native auth initialization successful');
-        print('📋 Token: ${authenticatedVendure.token?.substring(0, 20)}...');
+        print('📋 Token: ${authenticatedVendure.token?.substring!(0, 20)}...');
 
         // Test authenticated endpoint access
         try {
@@ -220,28 +220,28 @@ void main() {
       try {
         // First, get available products
         var products = await vendure.catalog.getProducts();
-        if (products.items.isEmpty) {
+        if (products.items!.isEmpty) {
           print('⚠️ No products available to test order creation');
           return;
         }
 
-        var firstProduct = products.items.first;
+        var firstProduct = products.items!.first;
         print('🛍️ Testing with product: ${firstProduct.name}');
 
         // Get product variants
-        if (firstProduct.variants.isEmpty) {
+        if (firstProduct.variants!.isEmpty) {
           print('⚠️ Product has no variants available');
           return;
         }
 
-        var firstVariant = firstProduct.variants.first;
+        var firstVariant = firstProduct.variants!.first;
         print(
-          '📦 Using variant: ${firstVariant.name} (ID: ${firstVariant.id})',
+          '📦 Using variant: ${firstVariant!.name} (ID: ${firstVariant.id})',
         );
 
         // Add item to order
         var result = await vendure.order.addItemToOrder(
-          productVariantId: firstVariant.id,
+          productVariantId: firstVariant!.id!,
           quantity: 1,
         );
         print(result);
@@ -254,7 +254,7 @@ void main() {
         print('✅ Successfully added item to guest order');
         print('📋 Order code: ${order.code}');
         print('📋 Order total: ${order.totalWithTax}');
-        print('📋 Line items: ${order.lines.length}');
+        print('📋 Line items: ${order.lines!.length}');
       } catch (e) {
         print('⚠️ Failed to create guest order: $e');
         // Don't fail test as this depends on product availability
@@ -289,9 +289,9 @@ void main() {
         print('✅ Search completed');
         print('📋 Found ${searchResult.totalItems} items for "laptop"');
 
-        if (searchResult.items.isNotEmpty) {
-          var firstResult = searchResult.items.first;
-          print('📋 First result: ${firstResult.productName}');
+        if (searchResult.items!.isNotEmpty) {
+          var firstResult = searchResult.items!.first;
+          print('📋 First result: ${firstResult!.productName}');
         }
       } catch (e) {
         print('⚠️ Search failed: $e');
@@ -301,11 +301,11 @@ void main() {
     test('Get collection by ID (if available)', () async {
       try {
         var collections = await vendure.catalog.getCollections();
-        if (collections.items.isNotEmpty) {
-          var firstCollection = collections.items.first;
+        if (collections.items!.isNotEmpty) {
+          var firstCollection = collections.items!.first;
 
           var collection = await vendure.catalog.getCollectionById(
-            id: firstCollection.id,
+            id: firstCollection.id!,
           );
 
           expect(collection, isA<Collection>());
@@ -325,17 +325,17 @@ void main() {
     test('Get product by ID (if available)', () async {
       try {
         var products = await vendure.catalog.getProducts();
-        if (products.items.isNotEmpty) {
-          var firstProduct = products.items.first;
+        if (products.items!.isNotEmpty) {
+          var firstProduct = products.items!.first;
 
           var product = await vendure.catalog.getProductById(
-            id: firstProduct.id,
+            id: firstProduct.id!,
           );
 
           expect(product, isA<Product>());
           print('✅ Retrieved product by ID');
           print('📋 Product: ${product.name}');
-          print('📋 Description: ${product.description.substring(0, 50)}...');
+          print('📋 Description: ${product.description!.substring(0, 50)}...');
         } else {
           print('ℹ️ No products available to test');
         }
@@ -355,7 +355,7 @@ void main() {
         print('⚠️ Expected error for invalid product variant, but got success');
       } catch (e) {
         print(
-          '✅ Correctly handled invalid product variant: ${e.toString().substring(0, 100)}...',
+          '✅ Correctly handled invalid product variant: ${e.toString().substring!(0, 100)}...',
         );
         expect(e, isNotNull);
       }
@@ -370,7 +370,7 @@ void main() {
         print('⚠️ Expected authentication error, but got success');
       } catch (e) {
         print(
-          '✅ Correctly handled invalid credentials: ${e.toString().substring(0, 100)}...',
+          '✅ Correctly handled invalid credentials: ${e.toString().substring!(0, 100)}...',
         );
         expect(e, isNotNull);
       }
@@ -382,7 +382,7 @@ void main() {
         print('⚠️ Expected error for invalid collection, but got success');
       } catch (e) {
         print(
-          '✅ Correctly handled invalid collection ID: ${e.toString().substring(0, 100)}...',
+          '✅ Correctly handled invalid collection ID: ${e.toString().substring!(0, 100)}...',
         );
         expect(e, isNotNull);
       }

--- a/test/isolated_guest_order_test.dart
+++ b/test/isolated_guest_order_test.dart
@@ -30,12 +30,12 @@ void main() {
         var products = await vendure.catalog.getProducts();
         expect(products.items, isNotEmpty);
 
-        var productWithVariants = products.items.firstWhere(
-          (p) => p.variants.isNotEmpty,
-          orElse: () => products.items.first,
+        var productWithVariants = products.items!.firstWhere(
+          (p) => p.variants!.isNotEmpty,
+          orElse: () => products.items!.first,
         );
 
-        testProductVariantId = productWithVariants.variants.first.id;
+        testProductVariantId = productWithVariants.variants!.first!.id!;
         print('✅ Found test product variant: ${productWithVariants.name}');
         print('📋 Variant ID: $testProductVariantId');
 

--- a/test/test_config.dart
+++ b/test/test_config.dart
@@ -146,10 +146,10 @@ class TestConfig {
 
     final variantIds = <String>{};
     for (final product in products.items) {
-      for (final variant in product.variants) {
+      for (final variant in product.variants!) {
         if (variantIds.length >= count) break;
-        if (variant.id.isNotEmpty) {
-          variantIds.add(variant.id);
+        if (variant!.id!.isNotEmpty) {
+          variantIds.add(variant!.id!);
         }
       }
       if (variantIds.length >= count) break;
@@ -173,7 +173,7 @@ class TestConfig {
     if (products.items.isEmpty) {
       throw StateError('No products available');
     }
-    return products.items.first.id;
+    return products.items!.first!.id!;
   }
 
   static Future<String> fetchAnyProductSlug(Vendure vendure) async {
@@ -183,7 +183,7 @@ class TestConfig {
     if (products.items.isEmpty) {
       throw StateError('No products available');
     }
-    return products.items.first.slug;
+    return products.items!.first!.slug!;
   }
 
   static Future<String> fetchAnyCollectionId(Vendure vendure) async {
@@ -191,7 +191,7 @@ class TestConfig {
     if (collections.items.isEmpty) {
       throw StateError('No collections available');
     }
-    return collections.items.first.id;
+    return collections.items!.first!.id!;
   }
 
   static Future<String> fetchAnyCollectionSlug(Vendure vendure) async {
@@ -199,7 +199,7 @@ class TestConfig {
     if (collections.items.isEmpty) {
       throw StateError('No collections available');
     }
-    return collections.items.first.slug;
+    return collections.items!.first!.slug!;
   }
 
   static String _toWebSocketUrl(String httpUrl) {

--- a/test/vendure_test.dart
+++ b/test/vendure_test.dart
@@ -48,8 +48,8 @@ void main() {
         Order order = Order.fromJson(result.toJson());
         expect(order, isA<Order>());
 
-        testOrderCode = order.code;
-        testOrderLineId = order.lines.first.id;
+        testOrderCode = order.code!;
+        testOrderLineId = order.lines!.first!.id!;
       } catch (e) {
         fail('Error adding item to cart: $e');
       }
@@ -96,8 +96,8 @@ void main() {
         Order order = Order.fromJson(result.toJson());
         expect(order, isA<Order>());
 
-        testOrderCode = order.code;
-        testOrderLineId = order.lines.first.id;
+        testOrderCode = order.code!;
+        testOrderLineId = order.lines!.first!.id!;
       } catch (e) {
         fail('Error adding item to cart: $e');
       }
@@ -243,7 +243,7 @@ void main() {
       try {
         var result = await vendure.order.getShippingMethods();
         expect(result, isA<List<ShippingMethodQuote>>());
-        shippingMethodId = result.first.id;
+        shippingMethodId = result.first!.id!;
       } catch (e) {
         fail('Error getting shipping methods: $e');
       }
@@ -267,7 +267,7 @@ void main() {
       try {
         var result = await vendure.order.getPaymentMethods();
         expect(result, isA<List<PaymentMethodQuote>>());
-        paymentMethodCode = result.first.code;
+        paymentMethodCode = result.first!.code!;
       } catch (e) {
         fail('Error getting payment methods: $e');
       }
@@ -340,7 +340,7 @@ void main() {
         expect(result, isA<AddPaymentToOrderResult>());
         Order order = Order.fromJson(result.toJson());
         expect(order, isA<Order>());
-        testOrderCode = order.code;
+        testOrderCode = order.code!;
       } catch (e) {
         fail('Error adding payment to order: $e');
       }
@@ -376,8 +376,8 @@ void main() {
         );
         order = Order.fromJson(result.toJson());
         expect(order, isA<Order>());
-        testOrderCode = order.code;
-        testOrderLineId = order.lines.first.id;
+        testOrderCode = order.code!;
+        testOrderLineId = order.lines!.first!.id!;
         print("passed 4");
 
         var customerResult = await vendure.order.setCustomerForOrder(
@@ -417,8 +417,8 @@ void main() {
         expect(order, isA<Order>());
         print("passed 8");
 
-        testOrderCode = order.code;
-        testOrderLineId = order.lines.first.id;
+        testOrderCode = order.code!;
+        testOrderLineId = order.lines!.first!.id!;
 
         var removedALine = await vendure.order.removeOrderLine(
           orderLineId: testOrderLineId,
@@ -472,7 +472,7 @@ void main() {
         expect(paymentMethodsResult, isA<List<PaymentMethodQuote>>());
         print("passed 14");
 
-        paymentMethodCode = paymentMethodsResult.first.code;
+        paymentMethodCode = paymentMethodsResult.first!.code!;
 
         var applyCouponResult = await vendure.order.applyCouponCode(
           couponCode: 'abc123',
@@ -507,7 +507,7 @@ void main() {
 
         var shippingMethods = await vendure.order.getShippingMethods();
         expect(shippingMethods, isA<List<ShippingMethodQuote>>());
-        shippingMethodId = shippingMethods.first.id;
+        shippingMethodId = shippingMethods!.first!.id!;
         print("passed 19");
 
         var shippingMethodResult = await vendure.order.setOrderShippingMethod(
@@ -547,7 +547,7 @@ void main() {
         expect(order.state, 'PaymentAuthorized');
         print("passed 23");
 
-        var paidOrder = await vendure.order.getOrderByCode(code: order.code);
+        var paidOrder = await vendure.order.getOrderByCode(code: order.code!);
         expect(paidOrder, isA<Order>());
         expect(paidOrder.state, 'PaymentAuthorized');
         print("passed 24");
@@ -571,7 +571,7 @@ void main() {
           options: options,
         );
         expect(collectionList, isA<CollectionList>());
-        for (var collection in collectionList.items) {
+        for (var collection in collectionList.items!) {
           expect(collection, isA<Collection>());
         }
       } catch (e) {
@@ -590,8 +590,8 @@ void main() {
           options: options,
         );
         expect(result, isA<CollectionList>());
-        if (result.items.isNotEmpty) {
-          for (var collection in result.items) {
+        if (result.items!.isNotEmpty) {
+          for (var collection in result.items!) {
             expect(collection, isA<Collection>());
           }
         }
@@ -609,7 +609,7 @@ void main() {
           options: options,
         );
         expect(collectionList, isA<CollectionList>());
-        for (var collection in collectionList.items) {
+        for (var collection in collectionList.items!) {
           expect(collection, isA<Collection>());
         }
       } catch (e) {
@@ -679,7 +679,7 @@ void main() {
         ProductListOptions options = ProductListOptions(take: 1);
         var products = await vendure.catalog.getProducts(options: options);
         expect(products, isA<ProductList>());
-        for (var product in products.items) {
+        for (var product in products.items!) {
           expect(product, isA<Product>());
         }
       } catch (e) {
@@ -712,7 +712,7 @@ void main() {
           input: searchInput,
         );
         expect(searchResponse, isA<SearchResponse>());
-        for (var searchResult in searchResponse.items) {
+        for (var searchResult in searchResponse.items!) {
           expect(searchResult, isA<SearchResult>());
         }
       } catch (e) {
@@ -736,7 +736,7 @@ void main() {
         FacetListOptions options = FacetListOptions(take: 1);
         var facets = await vendure.system.getFacets(options: options);
         expect(facets, isA<FacetList>());
-        for (var facet in facets.items) {
+        for (var facet in facets.items!) {
           expect(facet, isA<Facet>());
         }
       } catch (e) {
@@ -806,7 +806,7 @@ void main() {
           ),
         );
         expect(address, isA<Address>());
-        customerAddressId = address.id;
+        customerAddressId = address.id!;
       } catch (e) {
         fail('Error creating customer address: $e');
       }


### PR DESCRIPTION
Extracts GraphQL execution engine into VendureRemoteDataSource, re-wires CustomOperations to delegate, fixes union-type round-trip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a reusable data access layer for executing GraphQL queries and mutations.
  - Exposed the data source through the operations API for improved extensibility.
  - Added support for custom-field handling, response validation, list results, and JSON conversion.

- **Bug Fixes**
  - Improved compatibility with lowercase GraphQL result type identifiers across authentication, customer, order, payment, and search operations.
  - Corrected error messages for unsupported result variants.

- **Tests**
  - Updated integration and journey tests to safely handle nullable API response fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->