### PR TITLE
chore: gitignore .memsearch recall artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ schema.graphql
 .claude
 .agents
 .specify
+
+.memsearch


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to exclude `.memsearch` files and directories from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->